### PR TITLE
トップページのデータ取得をprefetchする形式に修正、細かなスタイル修正

### DIFF
--- a/src/components/StayCard/Rating.tsx
+++ b/src/components/StayCard/Rating.tsx
@@ -21,7 +21,7 @@ const icon = css`
 `;
 
 const ratingValue = css`
-  padding-left: 8px;
+  margin-left: 8px;
   font-family: Montserrat, sans-serif;
   font-size: 14px;
   font-style: normal;

--- a/src/components/StayCard/index.tsx
+++ b/src/components/StayCard/index.tsx
@@ -8,12 +8,9 @@ import { Stay } from '@/models/Stay';
 type Props = Stay;
 
 const StayCard: VFC<Props> = ({
-  city,
-  country,
   superHost,
   title,
   rating,
-  maxGuests,
   type,
   beds,
   photo,

--- a/src/hooks/useGetStayListQuery.ts
+++ b/src/hooks/useGetStayListQuery.ts
@@ -7,6 +7,7 @@ import {
 } from 'react-query';
 import { DEFAULT_API_OPTIONS } from '@/config/ky';
 import { Stay } from '@/models/Stay';
+import stays from '@/data/stays.json';
 
 const queryKey = 'stays';
 
@@ -21,8 +22,10 @@ const getStays = async (options?: Options): Promise<Stay[]> => {
   return data;
 };
 
+// getServerSidePropsでprefetchする用の関数
 const stayListPrefetchQuery = (queryClient: QueryClient) => {
-  return queryClient.prefetchQuery(queryKey, () => getStays());
+  // フェッチ関数に関して、外部APIであれば上記のリクエスト関数を使えばいいが、今回は内部APIなのでデータ部分を直接取得
+  return queryClient.prefetchQuery(queryKey, async () => stays);
 };
 
 const useGetStayListQuery = <TData = Stay[]>(

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ import StayCard from '@/components/StayCard';
 import { stayListPrefetchQuery, useGetStayListQuery } from '@/hooks';
 
 const Home = () => {
-  const { data } = useGetStayListQuery();
+  const { data } = useGetStayListQuery({ enabled: false });
 
   return (
     <Layout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,10 @@
+import { GetServerSideProps } from 'next';
 import { css } from '@emotion/react';
+import { QueryClient } from 'react-query';
+import { dehydrate } from 'react-query/hydration';
 import Layout from '@/components/Layout';
 import StayCard from '@/components/StayCard';
-import { useGetStayListQuery } from '@/hooks';
+import { stayListPrefetchQuery, useGetStayListQuery } from '@/hooks';
 
 const Home = () => {
   const { data } = useGetStayListQuery();
@@ -34,6 +37,18 @@ const Home = () => {
       </main>
     </Layout>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const queryClient = new QueryClient();
+
+  await stayListPrefetchQuery(queryClient);
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
 };
 
 const subHeader = css`


### PR DESCRIPTION
## Issue番号
#3 

## 対応内容
- データ取得部分はgetServerSidePropsでprefetchするよう修正
- 兄弟要素との余白は margin に統一
- 不要な props 削除